### PR TITLE
File_Mapper & Modified PageConfigController

### DIFF
--- a/app/Http/Controllers/API/PageConfigController.php
+++ b/app/Http/Controllers/API/PageConfigController.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use App\Models\API\PageConfig;
+use App\Models\FileMapper;
 use Illuminate\Support\Facades\Auth;
 use Validator;
 use Log;
@@ -14,112 +15,283 @@ use Log;
 class PageConfigController extends Controller
 {
 
-    public function store(Request $request): JsonResponse
-    {
-        $valRules = [
-            'page_type' => 'required|string',
-            'name' => 'required|string',
-            'description' => 'required|string',
-            'img_link' => 'required|string',
-            'parent' => 'required|integer',
-            'header_img' => 'required|string',
-            'header_text' => 'required|string',
-            'tenant_id' => 'required|integer',
-            'seq_no' => 'required|integer',
-            'language' => 'required|string'
-        ];
-        
-        $data = json_decode($request->getContent(), true);
-        $data['tenant_id'] = $request->header('tenant_id',0); 
-        $data['created_at'] = gmdate('Y-m-d H:i:s'); 
-        $data['updated_at'] = gmdate('Y-m-d H:i:s'); 
+   public function store(Request $request): JsonResponse
+{
+    $tenantId = $request->header('tenant_id');
+    $valRules = [
+        'page_type' => 'required|string',
+        'name' => 'required|string',
+        'description' => 'required|string',
+        'parent' => 'required|integer',
+        'header_img' => 'required|array',
+        'header_text' => 'required|string',
+        'seq_no' => 'required|integer',
+        'language' => 'required|string',
+        'page_url' => 'required|string',
+        'tenant_id' => 'required|integer|exists:tenants,id'
+    ];
 
-        $validator = Validator::make($data, $valRules);
+    $data = $request->all();
+    $data['tenant_id'] = $tenantId;
+    $data['created_at'] = gmdate('Y-m-d H:i:s');
+    $data['updated_at'] = gmdate('Y-m-d H:i:s');
 
-        if (!$validator->passes()) {
-            dd($validator->errors()->all());
-        }
+    $validator = Validator::make($data, $valRules);
 
-        $data['updated_by'] = Auth::user()->id;     
-       
-        $pageConfig = PageConfig::create($data);
-
+    if (!$validator->passes()) {
         return response()->json([
-            'data' => $pageConfig,
-            'message' => 'Success'
-        ], 200);
-
+            'success' => false,
+            'message' => 'Validation errors',
+            'errors' => $validator->errors()->all()
+        ], 422);
     }
 
-    public function update(Request $request): JsonResponse
-    {  
-        $valRules = [
-            'id' => 'required|integer',
-            'page_type' => 'required|string',
-            'name' => 'required|string',
-            'description' => 'required|string',
-            'img_link' => 'required|string',
-            'parent' => 'required|integer',
-            'header_img' => 'required|string',
-            'header_text' => 'required|string',
-            'tenant_id' => 'required|integer',
-            'seq_no' => 'required|integer',
-            'language' => 'required|string'
-        ];
+    $data['updated_by'] = Auth::user()->id;
 
-        $data = json_decode($request->getContent(), true);
-        $data['tenant_id'] = $request->header('tenant_id',0); 
-        $data['updated_at'] = gmdate('Y-m-d H:i:s');
+    // Extract header_img from data
+    $headerImg = $data['header_img'];
+    unset($data['header_img']);
 
-        $validator = Validator::make($data, $valRules);
+    $pageConfig = PageConfig::create($data);
 
-        if (!$validator->passes()) {
-            dd($validator->errors()->all());
-        }
-
-        $pageConfig = PageConfig::findOrFail($data['id']);
-        $pageConfig->fill($data);
-        $pageConfig->save();
-
-        return response()->json([
-            'pageConfig' => $pageConfig,
-            'message' => 'Success, Page Config updated successfully'
-        ], 200);
-
+    // Store header_img in FileMapper
+    foreach ($headerImg as $fileId) {
+        FileMapper::create([
+            'ref_id' => $pageConfig->id,
+            'ref_type' => 'page_config',
+            'file_id' => $fileId,
+            'updated_by' => $data['updated_by'],
+        ]);
     }
+
+    
+    $pageConfigArray = $pageConfig->toArray();
+    $pageConfigArray['header_img'] = $headerImg;
+
+    return response()->json([
+        'data' => $pageConfigArray,
+        'message' => 'Success'
+    ], 200);
+}
+
+
+
+   public function update(Request $request): JsonResponse
+{
+    $valRules = [
+        'id' => 'required|integer',
+        'page_type' => 'required|string',
+        'name' => 'required|string',
+        'description' => 'required|string',
+        'parent' => 'required|integer',
+        'header_img' => 'required|array',
+        'header_text' => 'required|string',
+        'page_url' => 'required|string',
+        'tenant_id' => 'required|integer',
+        'seq_no' => 'required|integer',
+        'language' => 'required|string'
+    ];
+
+    $data = $request->all();
+    $data['updated_at'] = gmdate('Y-m-d H:i:s');
+
+    $validator = Validator::make($data, $valRules);
+
+    if (!$validator->passes()) {
+        return response()->json([
+            'success' => false,
+            'message' => 'Validation errors',
+            'errors' => $validator->errors()->all()
+        ], 422);
+    }
+
+    // Extract header_img from data
+    $headerImg = $data['header_img'];
+    unset($data['header_img']);
+
+    $pageConfig = PageConfig::findOrFail($data['id']);
+    $pageConfig->fill($data);
+    $pageConfig->save();
+
+    // Fetch existing header_img entries
+    $existingHeaderImages = FileMapper::where('ref_id', $pageConfig->id)
+        ->where('ref_type', 'page_config')
+        ->pluck('file_id')
+        ->toArray();
+
+    // Determine entries to add and remove
+    $imagesToAdd = array_diff($headerImg, $existingHeaderImages);
+    $imagesToRemove = array_diff($existingHeaderImages, $headerImg);
+
+    // Delete obsolete header_img entries if there are any
+    if (count($imagesToRemove) > 0) {
+        FileMapper::where('ref_id', $pageConfig->id)
+            ->where('ref_type', 'page_config')
+            ->whereIn('file_id', $imagesToRemove)
+            ->delete();
+    }
+
+    // Add new header_img entries if there are any
+    if (count($imagesToAdd) > 0) {
+        foreach ($imagesToAdd as $fileId) {
+            FileMapper::create([
+                'ref_id' => $pageConfig->id,
+                'ref_type' => 'page_config',
+                'file_id' => $fileId,
+                'updated_by' => $data['updated_by'],
+            ]);
+        }
+    }
+
+  
+    $pageConfigArray = $pageConfig->toArray();
+    $pageConfigArray['header_img'] = $headerImg;
+
+    return response()->json([
+        'data' => $pageConfigArray,
+        'message' => 'Success, Page Config updated successfully'
+    ], 200);
+}
+
 
     public function all(Request $request)
-    {
-        $start = $request->input('start', 0);
-        $limit = $request->input('limit', 10); 
-        $tenantId = $request->header('tenant_id',0); 
-        $content = PageConfig::where([["tenant_id", $tenantId]])
-            ->offset($start)
-            ->limit($limit)
-            ->get();
-        return $content;
+{
+    
+    $tenantId = $request->header('tenant_id');
+
+    // Validate the tenant_id
+    $validator = Validator::make(['tenant_id' => $tenantId], [
+        'tenant_id' => 'required|integer|exists:tenants,id',
+    ]);
+
+    if ($validator->fails()) {
+        return response()->json([
+            'success' => false,
+            'message' => 'Validation errors',
+            'errors' => $validator->errors()
+        ], 422);
     }
+
+    $start = $request->input('start', 0);
+    $limit = $request->input('limit', 10); 
+
+    $pageConfigs = PageConfig::where('tenant_id', $tenantId)
+        ->offset($start)
+        ->limit($limit)
+        ->get();
+
+    if ($pageConfigs->isEmpty()) {
+        return response()->json([
+            'success' => false,
+            'message' => 'No records found for the provided tenant ID',
+        ], 404);
+    }
+
+    $pageConfigs->each(function ($pageConfig) {
+        $headerImages = FileMapper::where('ref_id', $pageConfig->id)
+            ->where('ref_type', 'page_config')
+            ->pluck('file_id')
+            ->toArray();
+        $pageConfig->header_img = $headerImages;
+    });
+
+    return response()->json($pageConfigs);
+}
+
     public function one(Request $request)
-    {
-        $request->validate([
-            'id' => 'required|integer',
-        ]);
-        $id = $request->input('id');
-        $tenantId = $request->header('tenant_id',0); 
-        $content = PageConfig::where([["tenant_id", $tenantId],["id",$id]])
-            ->first();
-        return $content;
+{
+ 
+    $tenantId = $request->header('tenant_id');
+    $headerValidator = Validator::make(['tenant_id' => $tenantId], [
+        'tenant_id' => 'required|integer|exists:tenants,id',
+    ]);
+
+    if ($headerValidator->fails()) {
+        return response()->json([
+            'success' => false,
+            'message' => 'Validation errors',
+            'errors' => $headerValidator->errors()
+        ], 422);
     }
+
+    
+    $request->validate([
+        'id' => 'required|integer|exists:page_config,id',
+    ]);
+
+    $id = $request->input('id');
+
+
+    $pageConfig = PageConfig::where([["tenant_id", $tenantId], ["id", $id]])->first();
+
+    if (!$pageConfig) {
+        return response()->json([
+            'success' => false,
+            'message' => 'Page configuration not found for the provided tenant ID and ID',
+        ], 404); 
+    }
+
+    // Fetch header images
+    $headerImages = FileMapper::where('ref_id', $pageConfig->id)
+        ->where('ref_type', 'page_config')
+        ->pluck('file_id')
+        ->toArray();
+    $pageConfig->header_img = $headerImages;
+
+    return response()->json($pageConfig);
+}
+
     public function destroy(Request $request)
-    {
-        $request->validate([
-            'id' => 'required|integer',
-        ]);
-        $id = $request->input('id');
-        $tenantId = $request->header('tenant_id',0); 
-        $response = PageConfig::where([["tenant_id",$tenantId],["id", $id]])->delete();
-        if ($response)
-            return "Page Config deleted successfully.";
-        else return "Page Config not found";
+{
+
+    $tenantId = $request->header('tenant_id');
+    $headerValidator = Validator::make(['tenant_id' => $tenantId], [
+        'tenant_id' => 'required|integer|exists:tenants,id',
+    ]);
+
+    if ($headerValidator->fails()) {
+        return response()->json([
+            'success' => false,
+            'message' => 'Validation errors',
+            'errors' => $headerValidator->errors()
+        ], 422);
     }
+
+   
+    $request->validate([
+        'id' => 'required|integer|exists:page_config,id',
+    ]);
+
+  
+    $id = $request->input('id');
+
+    // Check if the PageConfig exists
+    $pageConfig = PageConfig::where([["tenant_id", $tenantId], ["id", $id]])->first();
+
+    if (!$pageConfig) {
+        return response()->json([
+            'success' => false,
+            'message' => 'Page Config not found for the provided tenant ID and ID',
+        ], 404); 
+    }
+
+    // Delete related entries in the file_mapper table
+    FileMapper::where('ref_id', $id)->where('ref_type', 'page_config')->delete();
+
+    // Delete the PageConfig record
+    $response = $pageConfig->delete();
+
+    if ($response) {
+        return response()->json([
+            'success' => true,
+            'message' => 'Page Config deleted successfully.',
+        ], 200); 
+    } else {
+        return response()->json([
+            'success' => false,
+            'message' => 'Page Config could not be deleted',
+        ], 500); 
+    }
+}
+
 }

--- a/app/Models/API/PageConfig.php
+++ b/app/Models/API/PageConfig.php
@@ -1,9 +1,13 @@
 <?php
 
+
 namespace App\Models\API;
+
+
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\FileMapper; 
 
 class PageConfig extends Model
 {
@@ -15,14 +19,17 @@ class PageConfig extends Model
         'page_url',
         'name',
         'description',
-        'img_link',
         'parent',
-        'header_img',
         'header_text',
         'updated_by',
         'tenant_id',
         'language',
         'seq_no'
-    ];
+    ]; 
+
+    public function headerImages()
+    {
+        return $this->hasMany(FileMapper::class, 'ref_id')->where('ref_type', 'page_config')->where('type', 'header_image');
+    }
 
 }

--- a/app/Models/FileMapper.php
+++ b/app/Models/FileMapper.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\API\PageConfig; 
+use App\Models\API\Content; 
+use App\Models\API\File; 
+
+class FileMapper extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ref_id',
+        'ref_type',
+        'file_id',
+        'updated_by'
+    ];
+
+    public function pageConfig()
+    {
+        return $this->belongsTo(PageConfig::class, 'ref_id')->where('ref_type', 'page_config');
+    }
+
+    public function content()
+    {
+        return $this->belongsTo(Content::class, 'ref_id')->where('ref_type', 'content');
+    }
+
+    public function file()
+    {
+        return $this->belongsTo(File::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+}

--- a/app/Models/FileMapper.php
+++ b/app/Models/FileMapper.php
@@ -12,6 +12,8 @@ class FileMapper extends Model
 {
     use HasFactory;
 
+    protected $table = 'file_mapper';
+
     protected $fillable = [
         'ref_id',
         'ref_type',

--- a/database/migrations/2024_05_27_213922_remove_header_img_and_img_link_from_page_config_table.php
+++ b/database/migrations/2024_05_27_213922_remove_header_img_and_img_link_from_page_config_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('page_config', function (Blueprint $table) {
+            $table->dropColumn('header_img');
+            $table->dropColumn('img_link');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('page_config', function (Blueprint $table) {
+            $table->string('header_img')->nullable();
+            $table->string('img_link')->nullable();
+        });
+    }
+};

--- a/database/migrations/2024_05_27_215801_create_file_mapper_table.php
+++ b/database/migrations/2024_05_27_215801_create_file_mapper_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('file_mapper', function (Blueprint $table) {
+             $table->id();
+            $table->unsignedBigInteger('ref_id'); // General reference ID
+            $table->string('ref_type'); // Type of reference, e.g., 'page_config'
+            $table->unsignedBigInteger('file_id'); 
+            $table->timestamps();
+            $table->unsignedBigInteger('updated_by'); 
+
+            // Foreign keys
+            $table->foreign('file_id')->references('id')->on('files')->onDelete('cascade');
+            $table->foreign('updated_by')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('file_mapper');
+    }
+};

--- a/database/seeders/FileSeeder.php
+++ b/database/seeders/FileSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class FileSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Dummy data for files
+        $files = [
+            ['group_id' => 1, 'file_id' => '12345', 'file_name' => 'file1.jpg', 'created_at' => now(), 'updated_at' => now()],
+            ['group_id' => 1, 'file_id' => '23456', 'file_name' => 'file2.jpg', 'created_at' => now(), 'updated_at' => now()],
+            ['group_id' => 2, 'file_id' => '34567', 'file_name' => 'file3.jpg', 'created_at' => now(), 'updated_at' => now()],
+            ['group_id' => 2, 'file_id' => '45678', 'file_name' => 'file4.jpg', 'created_at' => now(), 'updated_at' => now()],
+        ];
+
+        // Insert the dummy data into the files table
+        DB::table('files')->insert($files);
+    }
+}


### PR DESCRIPTION


This pull request includes:

1. **Added File Mapper Table**:
   - Created `file_mapper` table to map files to entities like `page_config`.

2. **Modified PageConfigController**:
   - Handle `header_img` as an array of file IDs.
   - Update validation and create `file_mapper` entries.
   - Efficiently update `header_img` in `file_mapper`.
   - Validate `tenant_id` and fetch `header_img` from `file_mapper` for `page_config` response json.